### PR TITLE
fix: show Campaigns and Reports in sidebar for all tiers

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -44,9 +44,9 @@ const navigation: NavItem[] = [
   { name: "Leads", href: "/leads", icon: Building2 },
   { name: "Contacts", href: "/contacts", icon: Users },
   { name: "Activities", href: "/activities", icon: Activity },
-  { name: "Campaigns", href: "/campaigns", icon: Megaphone, requiredFeature: "campaigns" },
+  { name: "Campaigns", href: "/campaigns", icon: Megaphone },
+  { name: "Reports", href: "/reports", icon: BarChart3 },
   { name: "Automation", href: "/automation", icon: Zap, requiredFeature: "automationRules" },
-  { name: "Reports", href: "/reports", icon: FileText, requiredFeature: "savedReports" },
 ];
 
 const adminNavigation: NavItem[] = [


### PR DESCRIPTION
## Summary

- Remove `requiredFeature` gate from **Campaigns** and **Reports** sidebar nav items
- These were hidden for free-tier users because `campaigns=0` and `savedReports=0` caused `canFeature()` to return false
- Core navigation should always be visible — feature limits should gate creation/usage within pages, not sidebar visibility
- Swaps Reports icon from `FileText` to `BarChart3` for better visual clarity

Closes #20, #21

## Test Plan

- [ ] Log in as free-tier user — Campaigns and Reports links should appear in sidebar
- [ ] Click Campaigns link — navigates to `/campaigns`
- [ ] Click Reports link — navigates to `/reports`
- [ ] Verify Automation link is still gated by subscription tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)