### PR TITLE
fix: dashboard chart and UI bugs (#23-#26)

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -57,6 +57,14 @@ export default function DashboardPage() {
     ? ((stats.newLeadsThisWeek - stats.newLeadsPreviousWeek) / stats.newLeadsPreviousWeek) * 100
     : 0;
 
+  const pipelineChange = stats && stats.previousPipelineValue > 0
+    ? ((stats.pipelineValue - stats.previousPipelineValue) / stats.previousPipelineValue) * 100
+    : 0;
+
+  const conversionChange = stats && stats.previousConversionRate > 0
+    ? stats.conversionRate - stats.previousConversionRate
+    : 0;
+
   // Prepare source distribution data
   const sourceData = stats?.sourceCounts
     ? Object.entries(stats.sourceCounts)
@@ -104,6 +112,8 @@ export default function DashboardPage() {
         <KPICard
           title="Pipeline Value"
           value={stats ? formatCurrency(stats.pipelineValue) : "$0"}
+          change={pipelineChange}
+          changeLabel="vs last week"
           icon={DollarSign}
           iconColor="text-gold"
           isLoading={statsLoading}
@@ -112,6 +122,8 @@ export default function DashboardPage() {
         <KPICard
           title="Conversion Rate"
           value={stats ? `${stats.conversionRate.toFixed(1)}%` : "0%"}
+          change={conversionChange}
+          changeLabel="pp vs last week"
           icon={Target}
           isLoading={statsLoading}
           href="/reports"

--- a/components/dashboard/Charts.tsx
+++ b/components/dashboard/Charts.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import {
   LineChart,
   Line,
@@ -20,6 +21,15 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
 import { formatCurrency, formatCompactNumber } from "@/lib/utils/formatters";
 import type { ChartDataPoint, PipelineFunnelData } from "@/lib/hooks/useAnalytics";
+
+// Prevents Recharts "Cannot read properties of undefined" and dimension
+// warnings that fire when ResponsiveContainer renders before the parent
+// element has a non-zero size (e.g. during SSR or first paint).
+function useMounted() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted;
+}
 
 interface ChartContainerProps {
   title: string;
@@ -68,10 +78,11 @@ interface LeadsTrendChartProps {
 }
 
 export function LeadsTrendChart({ data, title = "Leads Trend", icon, isLoading }: LeadsTrendChartProps) {
+  const mounted = useMounted();
   return (
     <ChartContainer title={title} icon={icon} isLoading={isLoading}>
       <div className="h-[300px]">
-        <ResponsiveContainer width="100%" height="100%">
+        {mounted && <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
             <defs>
               <linearGradient id="colorLeads" x1="0" y1="0" x2="0" y2="1">
@@ -92,6 +103,7 @@ export function LeadsTrendChart({ data, title = "Leads Trend", icon, isLoading }
               fontSize={12}
               tickLine={false}
               axisLine={false}
+              allowDecimals={false}
             />
             <Tooltip
               contentStyle={{
@@ -109,7 +121,7 @@ export function LeadsTrendChart({ data, title = "Leads Trend", icon, isLoading }
               fill="url(#colorLeads)"
             />
           </AreaChart>
-        </ResponsiveContainer>
+        </ResponsiveContainer>}
       </div>
     </ChartContainer>
   );
@@ -123,10 +135,11 @@ interface RevenueTrendChartProps {
 }
 
 export function RevenueTrendChart({ data, title = "Revenue Trend", icon, isLoading }: RevenueTrendChartProps) {
+  const mounted = useMounted();
   return (
     <ChartContainer title={title} icon={icon} isLoading={isLoading}>
       <div className="h-[300px]">
-        <ResponsiveContainer width="100%" height="100%">
+        {mounted && <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
             <XAxis
@@ -161,7 +174,7 @@ export function RevenueTrendChart({ data, title = "Revenue Trend", icon, isLoadi
               activeDot={{ r: 6 }}
             />
           </LineChart>
-        </ResponsiveContainer>
+        </ResponsiveContainer>}
       </div>
     </ChartContainer>
   );
@@ -175,10 +188,11 @@ interface PipelineFunnelChartProps {
 }
 
 export function PipelineFunnelChart({ data, title = "Pipeline Overview", icon, isLoading }: PipelineFunnelChartProps) {
+  const mounted = useMounted();
   return (
     <ChartContainer title={title} icon={icon} isLoading={isLoading}>
       <div className="h-[300px]">
-        <ResponsiveContainer width="100%" height="100%">
+        {mounted && <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={data}
             layout="vertical"
@@ -191,6 +205,7 @@ export function PipelineFunnelChart({ data, title = "Pipeline Overview", icon, i
               fontSize={12}
               tickLine={false}
               axisLine={false}
+              allowDecimals={false}
             />
             <YAxis
               type="category"
@@ -218,7 +233,7 @@ export function PipelineFunnelChart({ data, title = "Pipeline Overview", icon, i
               ))}
             </Bar>
           </BarChart>
-        </ResponsiveContainer>
+        </ResponsiveContainer>}
       </div>
     </ChartContainer>
   );
@@ -234,10 +249,11 @@ interface SourceDistributionChartProps {
 const COLORS = ["#d4af37", "#6366f1", "#22c55e", "#f97316", "#ec4899", "#8b5cf6", "#06b6d4", "#eab308"];
 
 export function SourceDistributionChart({ data, title = "Lead Sources", icon, isLoading }: SourceDistributionChartProps) {
+  const mounted = useMounted();
   return (
     <ChartContainer title={title} icon={icon} isLoading={isLoading}>
       <div className="h-[300px]">
-        <ResponsiveContainer width="100%" height="100%">
+        {mounted && <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
               data={data}
@@ -265,7 +281,7 @@ export function SourceDistributionChart({ data, title = "Lead Sources", icon, is
               formatter={(value) => <span className="text-text-secondary">{value}</span>}
             />
           </PieChart>
-        </ResponsiveContainer>
+        </ResponsiveContainer>}
       </div>
     </ChartContainer>
   );

--- a/components/dashboard/DateRangeSelector.tsx
+++ b/components/dashboard/DateRangeSelector.tsx
@@ -99,7 +99,7 @@ export function DateRangeSelector({ value, onChange }: DateRangeSelectorProps) {
   };
 
   return (
-    <div className="relative">
+    <div className="relative z-50">
       <Button
         variant="secondary"
         size="sm"

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -14,9 +14,11 @@ export interface DashboardStats {
   newLeadsThisWeek: number;
   newLeadsPreviousWeek: number;
   pipelineValue: number;
+  previousPipelineValue: number;
   wonDealsCount: number;
   wonDealsValue: number;
   conversionRate: number;
+  previousConversionRate: number;
   avgDealSize: number;
   totalActivities: number;
   activitiesToday: number;
@@ -86,12 +88,31 @@ export function useDashboardStats(dateRange?: DateRange) {
         0
       ) || 0;
 
+      // Previous pipeline value (pipeline from leads created before this week)
+      const previousPipelineLeads = leads?.filter(
+        (l) =>
+          new Date(l.created_at) < weekAgo &&
+          !["won", "lost", "do_not_contact"].includes(l.status)
+      );
+      const previousPipelineValue = previousPipelineLeads?.reduce(
+        (sum, l) => sum + (l.deal_value || 0),
+        0
+      ) || 0;
+
       // Conversion rate
-      const qualifiedOrBetter = leads?.filter((l) =>
-        ["qualified", "proposal", "negotiation", "won"].includes(l.status)
-      ).length || 0;
       const conversionRate = totalLeads > 0
         ? (wonDealsCount / totalLeads) * 100
+        : 0;
+
+      // Previous conversion rate (leads created before this week)
+      const leadsBeforeThisWeek = leads?.filter(
+        (l) => new Date(l.created_at) < weekAgo
+      );
+      const wonBeforeThisWeek = leadsBeforeThisWeek?.filter(
+        (l) => l.status === "won"
+      ).length || 0;
+      const previousConversionRate = leadsBeforeThisWeek?.length
+        ? (wonBeforeThisWeek / leadsBeforeThisWeek.length) * 100
         : 0;
 
       // Average deal size
@@ -146,9 +167,11 @@ export function useDashboardStats(dateRange?: DateRange) {
         newLeadsThisWeek,
         newLeadsPreviousWeek,
         pipelineValue,
+        previousPipelineValue,
         wonDealsCount,
         wonDealsValue,
         conversionRate,
+        previousConversionRate,
         avgDealSize,
         totalActivities,
         activitiesToday,


### PR DESCRIPTION
## Summary
- **Issue #23**: Add `useMounted()` guard to all 4 Recharts chart components (LeadsTrend, RevenueTrend, PipelineFunnel, SourceDistribution) — prevents 150+ dimension warnings by deferring ResponsiveContainer render until after mount
- **Issue #24**: Add `allowDecimals={false}` to YAxis (LeadsTrend) and XAxis (PipelineFunnel) so integer data doesn't show fractional tick values like 0.25, 0.5, 0.75
- **Issue #25**: Add `previousPipelineValue` and `previousConversionRate` to `useDashboardStats` hook, compute week-over-week change percentages, and pass them to Pipeline Value and Conversion Rate KPICards
- **Issue #26**: Add `z-50` to DateRangeSelector container so the toggle button sits above the `z-40` backdrop overlay, allowing second-click to properly close the dropdown

## Files Changed
- `components/dashboard/Charts.tsx` — mount guard + allowDecimals
- `lib/hooks/useAnalytics.ts` — previous period comparison data
- `app/(dashboard)/dashboard/page.tsx` — pass change props to KPICards
- `components/dashboard/DateRangeSelector.tsx` — z-index fix

## Test plan
- [ ] Open dashboard — verify no Recharts dimension warnings in console
- [ ] Verify New Leads chart Y-axis shows only whole numbers
- [ ] Verify Pipeline Value and Conversion Rate cards show comparison arrows/text
- [ ] Click date filter button twice — verify dropdown opens then closes

Closes #23, closes #24, closes #25, closes #26

Generated with [Claude Code](https://claude.com/claude-code)