### PR TITLE
fix: remove unsafe-eval from CSP and consolidate rate limiting

### DIFF
--- a/lib/utils/security.ts
+++ b/lib/utils/security.ts
@@ -149,7 +149,7 @@ export function sanitizeSearchInput(input: string): string {
 export function generateCSPHeader(): string {
   return [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "script-src 'self' 'unsafe-inline' https://js.stripe.com",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https:",
     "font-src 'self' data:",

--- a/middleware.ts
+++ b/middleware.ts
@@ -107,7 +107,7 @@ export async function middleware(request: NextRequest) {
   );
   response.headers.set(
     "Content-Security-Policy",
-    "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com; frame-src https://js.stripe.com;"
+    "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com; frame-src https://js.stripe.com;"
   );
 
   return response;


### PR DESCRIPTION
## Summary
- **Remove `'unsafe-eval'` from CSP** in both `middleware.ts` and `lib/utils/security.ts` to mitigate XSS risks via `eval()`/`Function()` constructors (fixes #14)
- **Consolidate 4 duplicate rate limiting implementations** into the shared `rateLimit()` utility from `lib/utils/security.ts` (fixes #18)

## Changes
| File | Change |
|------|--------|
| `middleware.ts` | Removed `'unsafe-eval'` from CSP header |
| `lib/utils/security.ts` | Removed `'unsafe-eval'` from `generateCSPHeader()`, added Stripe domain |
| `app/api/leads/export/route.ts` | Replaced custom `rateLimitMap` with shared `rateLimit()` |
| `app/api/leads/import/route.ts` | Replaced custom `rateLimitMap` with shared `rateLimit()` |
| `app/api/webhooks/n8n/route.ts` | Replaced custom `rateLimitMap` with shared `rateLimit()` |
| `app/api/webhooks/email-inbound/route.ts` | Replaced custom `rateLimitMap` with shared `rateLimit()` |

## Why
- `'unsafe-eval'` allows attackers to execute arbitrary JS via `eval()` if they find an injection point — removing it is a CSP best practice
- The 4 custom `Map`-based rate limiters were unbounded (no TTL/eviction), risking memory leaks under sustained load. The shared `rateLimit()` uses `LRUCache` with proper TTL and max size

## Test plan
- [ ] Verify app loads without CSP errors in browser console
- [ ] Verify rate limiting still works on export, import, n8n, and email-inbound endpoints
- [ ] Run existing E2E tests (`node tests/e2e-full-test.mjs`)

Closes #14, Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)