### PR TITLE
fix: persistent rate limiting and hardened CSP (#14, #18)

### DIFF
--- a/app/api/email/send/route.ts
+++ b/app/api/email/send/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Rate limit: 20 emails per minute per user
-    const rateLimitResult = rateLimit(`email:${user.id}`, 20, 60000);
+    const rateLimitResult = await rateLimit(`email:${user.id}`, 20, 60000);
     if (!rateLimitResult.success) {
       return NextResponse.json(
         { error: "Rate limit exceeded" },

--- a/app/api/leads/export/route.ts
+++ b/app/api/leads/export/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    if (!rateLimit(`export:${user.id}`, 5, 60000).success) {
+    if (!(await rateLimit(`export:${user.id}`, 5, 60000)).success) {
       return NextResponse.json({ error: "Rate limit exceeded. Max 5 exports per minute." }, { status: 429 });
     }
 

--- a/app/api/leads/import/route.ts
+++ b/app/api/leads/import/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    if (!rateLimit(`import:${user.id}`, 10, 60000).success) {
+    if (!(await rateLimit(`import:${user.id}`, 10, 60000)).success) {
       return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
     }
 

--- a/app/api/webhooks/email-inbound/route.ts
+++ b/app/api/webhooks/email-inbound/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
   try {
     const ip = request.headers.get("x-forwarded-for") || "unknown";
 
-    if (!rateLimit(`email-inbound:${ip}`, 100, 60000).success) {
+    if (!(await rateLimit(`email-inbound:${ip}`, 100, 60000)).success) {
       return NextResponse.json({ error: "Rate limit exceeded" }, { status: 429 });
     }
 

--- a/app/api/webhooks/n8n/route.ts
+++ b/app/api/webhooks/n8n/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
     const ip = request.headers.get("x-forwarded-for") || "unknown";
 
     // Rate limiting check
-    if (!rateLimit(`n8n:${ip}`, 100, 60000).success) {
+    if (!(await rateLimit(`n8n:${ip}`, 100, 60000)).success) {
       return NextResponse.json(
         { error: "Rate limit exceeded" },
         { status: 429 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -105,9 +105,25 @@ export async function middleware(request: NextRequest) {
     "Strict-Transport-Security",
     "max-age=31536000; includeSubDomains"
   );
+  // CSP: unsafe-inline is required for Next.js inline scripts and Tailwind styles.
+  // unsafe-eval is NOT included — Next.js production builds do not require it.
+  // frame-ancestors 'none' replaces X-Frame-Options for modern browsers.
   response.headers.set(
     "Content-Security-Policy",
-    "default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com; frame-src https://js.stripe.com;"
+    [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' https://js.stripe.com",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.stripe.com",
+      "frame-src https://js.stripe.com",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "object-src 'none'",
+      "upgrade-insecure-requests",
+    ].join("; ")
   );
 
   return response;

--- a/supabase/migrations/20260212000000_persistent_rate_limiting.sql
+++ b/supabase/migrations/20260212000000_persistent_rate_limiting.sql
@@ -1,0 +1,57 @@
+-- Persistent rate limiting table (replaces in-memory LRU cache)
+-- Works across serverless instances and survives restarts
+
+CREATE TABLE IF NOT EXISTS public.rate_limit_entries (
+  identifier TEXT NOT NULL,
+  request_time TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_rate_limit_lookup
+  ON public.rate_limit_entries (identifier, request_time DESC);
+
+-- Atomic check-and-record function
+-- Returns: allowed (boolean), remaining (int)
+CREATE OR REPLACE FUNCTION public.check_rate_limit(
+  p_identifier TEXT,
+  p_limit INT DEFAULT 60,
+  p_window_seconds INT DEFAULT 60
+) RETURNS TABLE(allowed BOOLEAN, remaining INT) LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_window_start TIMESTAMPTZ;
+  v_count INT;
+BEGIN
+  v_window_start := now() - make_interval(secs => p_window_seconds);
+
+  -- Clean up old entries for this identifier
+  DELETE FROM public.rate_limit_entries
+  WHERE identifier = p_identifier AND request_time < v_window_start;
+
+  -- Count requests in current window
+  SELECT count(*) INTO v_count
+  FROM public.rate_limit_entries
+  WHERE identifier = p_identifier AND request_time >= v_window_start;
+
+  IF v_count >= p_limit THEN
+    RETURN QUERY SELECT false, 0;
+    RETURN;
+  END IF;
+
+  -- Record this request
+  INSERT INTO public.rate_limit_entries (identifier, request_time)
+  VALUES (p_identifier, now());
+
+  RETURN QUERY SELECT true, (p_limit - v_count - 1);
+END;
+$$;
+
+-- Global cleanup function (call periodically or via pg_cron)
+CREATE OR REPLACE FUNCTION public.cleanup_rate_limits()
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  DELETE FROM public.rate_limit_entries
+  WHERE request_time < now() - interval '5 minutes';
+END;
+$$;
+
+-- No RLS on rate_limit_entries — only accessed via service role / SECURITY DEFINER functions
+ALTER TABLE public.rate_limit_entries ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

### Rate Limiting (#18) - Persistent across serverless instances
- **New migration** `20260212000000_persistent_rate_limiting.sql`: Creates `rate_limit_entries` table and `check_rate_limit()` Postgres function that atomically checks request count, cleans up expired entries, and records new requests
- **Updated `lib/utils/security.ts`**: `rateLimit()` is now `async` — calls Supabase `check_rate_limit` RPC for persistent storage, falls back to in-memory LRU cache if Supabase is unavailable
- **Updated 5 API route callers** to `await` the async `rateLimit()`:
  - `/api/webhooks/n8n` (100/min per IP)
  - `/api/webhooks/email-inbound` (100/min per IP)
  - `/api/leads/export` (5/min per user)
  - `/api/leads/import` (10/min per user)
  - `/api/email/send` (20/min per user)

### CSP Hardening (#14) - Removed unsafe-eval, added missing directives
- Confirmed `unsafe-eval` is **not present** (Next.js production builds don't need it)
- Added missing directives: `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'`, `object-src 'none'`, `upgrade-insecure-requests`
- Synced `generateCSPHeader()` in security.ts with middleware CSP
- `unsafe-inline` remains required for Next.js inline scripts and Tailwind CSS

## Files Changed
- `supabase/migrations/20260212000000_persistent_rate_limiting.sql` — new table + RPC function
- `lib/utils/security.ts` — async rateLimit with Supabase backend + fallback
- `middleware.ts` — hardened CSP with 5 additional directives
- 5 API route files — `await rateLimit()` calls

## Test plan
- [ ] Hit `/api/leads/export` 6 times rapidly — verify 429 on 6th request
- [ ] Restart dev server, hit export again — verify rate limit counter persists (not reset)
- [ ] Check response headers include all new CSP directives
- [ ] Verify `unsafe-eval` is NOT in CSP header
- [ ] Verify app functions normally (no CSP violations blocking Supabase/Stripe)

Closes #14, closes #18

Generated with [Claude Code](https://claude.com/claude-code)