### PR TITLE
fix: CSP dev mode unsafe-eval + UI clipping fixes

### DIFF
--- a/app/(dashboard)/campaigns/page.tsx
+++ b/app/(dashboard)/campaigns/page.tsx
@@ -104,7 +104,7 @@ export default function CampaignsPage() {
 
       {/* Filters */}
       <div className="flex flex-col sm:flex-row gap-4">
-        <div className="flex-1">
+        <div className="flex-1 min-w-0 sm:min-w-[200px]">
           <Input
             placeholder="Search campaigns..."
             value={searchQuery}
@@ -112,7 +112,7 @@ export default function CampaignsPage() {
             leftIcon={<Search className="h-4 w-4" />}
           />
         </div>
-        <div className="flex gap-3">
+        <div className="flex gap-3 shrink-0">
           <Select
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}

--- a/components/layout/DashboardShell.tsx
+++ b/components/layout/DashboardShell.tsx
@@ -13,7 +13,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
         isMobileOpen={mobileOpen}
         onMobileClose={() => setMobileOpen(false)}
       />
-      <div className="md:pl-64 transition-all duration-300">
+      <div className="md:pl-64 transition-all duration-300 overflow-x-hidden">
         <Header onMenuClick={() => setMobileOpen(true)} />
         <main className="p-4 md:p-6">{children}</main>
       </div>

--- a/lib/utils/security.ts
+++ b/lib/utils/security.ts
@@ -188,9 +188,10 @@ export function sanitizeSearchInput(input: string): string {
 
 // Content Security Policy Header Generator
 export function generateCSPHeader(): string {
+  const isDev = process.env.NODE_ENV === "development";
   return [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://js.stripe.com",
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://js.stripe.com`,
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https:",
     "font-src 'self' data:",
@@ -200,7 +201,7 @@ export function generateCSPHeader(): string {
     "base-uri 'self'",
     "form-action 'self'",
     "object-src 'none'",
-    "upgrade-insecure-requests",
+    ...(isDev ? [] : ["upgrade-insecure-requests"]),
   ].join("; ");
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -106,13 +106,14 @@ export async function middleware(request: NextRequest) {
     "max-age=31536000; includeSubDomains"
   );
   // CSP: unsafe-inline is required for Next.js inline scripts and Tailwind styles.
-  // unsafe-eval is NOT included — Next.js production builds do not require it.
+  // unsafe-eval is required in dev mode for React Fast Refresh but excluded in production.
   // frame-ancestors 'none' replaces X-Frame-Options for modern browsers.
+  const isDev = process.env.NODE_ENV === "development";
   response.headers.set(
     "Content-Security-Policy",
     [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' https://js.stripe.com",
+      `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://js.stripe.com`,
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https:",
       "font-src 'self' data:",
@@ -122,7 +123,7 @@ export async function middleware(request: NextRequest) {
       "base-uri 'self'",
       "form-action 'self'",
       "object-src 'none'",
-      "upgrade-insecure-requests",
+      ...(isDev ? [] : ["upgrade-insecure-requests"]),
     ].join("; ")
   );
 


### PR DESCRIPTION
## Summary
- **CSP `unsafe-eval` for dev mode only** — Next.js React Fast Refresh requires `eval()` to work. The previous PR (#41) removed `unsafe-eval` entirely, which broke hot reload and caused 41+ `EvalError` CSP violations per page, preventing the app from loading data in dev mode.
- **Skip `upgrade-insecure-requests` in dev** — localhost runs on HTTP, so this directive was causing mixed-content issues in development.
- **Fix profile avatar clipping** — Added `overflow-x-hidden` to the dashboard content wrapper in `DashboardShell.tsx` to prevent the header right side from extending past the viewport edge.
- **Fix campaigns search truncation** — The search input placeholder showed "Se..." instead of "Search campaigns..." because flex siblings compressed its width. Added `min-w-[200px]` and `shrink-0` on the adjacent filter selects.

## Changes
| File | Change |
|------|--------|
| `middleware.ts` | CSP `script-src` conditionally includes `'unsafe-eval'` when `NODE_ENV=development` |
| `lib/utils/security.ts` | Same conditional in `generateCSPHeader()` |
| `components/layout/DashboardShell.tsx` | Added `overflow-x-hidden` to content wrapper |
| `app/(dashboard)/campaigns/page.tsx` | Added `min-w-0 sm:min-w-[200px]` on search container, `shrink-0` on filter selects |

## Test plan
- [ ] Verify dev mode: no CSP EvalError in browser console, React Fast Refresh works
- [ ] Verify all dashboard pages load data (no infinite skeleton states)
- [ ] Verify profile avatar is not clipped on right edge
- [ ] Verify campaigns search input shows full placeholder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)