### PR TITLE
fix: admin mode data refresh, campaign title/plan gating

### DIFF
--- a/components/campaigns/CampaignCard.tsx
+++ b/components/campaigns/CampaignCard.tsx
@@ -71,7 +71,7 @@ export function CampaignCard({ campaign, onStatusChange }: CampaignCardProps) {
                 {typeIcon}
               </div>
               <div>
-                <h3 className="font-medium text-text-primary line-clamp-1">
+                <h3 className="font-medium text-text-primary line-clamp-2">
                   {campaign.name}
                 </h3>
                 <p className="text-xs text-text-muted capitalize">

--- a/lib/hooks/useActivities.ts
+++ b/lib/hooks/useActivities.ts
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getSupabaseClient } from "@/lib/supabase/client";
 import type { Tables, InsertTables } from "@/lib/types/database";
 import { useRealtimeSubscription } from "@/lib/hooks/useRealtime";
+import { useViewMode } from "@/lib/contexts/ViewModeContext";
 
 type ActivityWithProfile = Tables<"activities"> & {
   profiles: { full_name: string | null } | null;
@@ -19,10 +20,11 @@ export interface ActivityFilters {
 
 export function useActivities(filters: ActivityFilters = {}) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
   useRealtimeSubscription("activities", [["activities"]]);
 
   return useQuery({
-    queryKey: ["activities", filters],
+    queryKey: ["activities", filters, isAdminView],
     queryFn: async () => {
       let query = supabase
         .from("activities")

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getSupabaseClient } from "@/lib/supabase/client";
 import { subDays, startOfDay, endOfDay, format, subWeeks, subMonths } from "date-fns";
+import { useViewMode } from "@/lib/contexts/ViewModeContext";
 
 export interface DateRange {
   from: Date;
@@ -42,9 +43,10 @@ export interface PipelineFunnelData {
 
 export function useDashboardStats(dateRange?: DateRange) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["dashboardStats", dateRange?.from?.toISOString(), dateRange?.to?.toISOString()],
+    queryKey: ["dashboardStats", dateRange?.from?.toISOString(), dateRange?.to?.toISOString(), isAdminView],
     queryFn: async () => {
       // Get all leads
       const { data: leads, error: leadsError } = await supabase
@@ -191,9 +193,10 @@ export interface FollowUpStats {
 
 export function useFollowUpStats() {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["followUpStats"],
+    queryKey: ["followUpStats", isAdminView],
     queryFn: async () => {
       const today = format(new Date(), "yyyy-MM-dd");
       const sevenDaysAgo = format(subDays(new Date(), 7), "yyyy-MM-dd'T'HH:mm:ss");
@@ -237,9 +240,10 @@ export function useFollowUpStats() {
 
 export function useLeadsTrend(days: number = 30) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["leadsTrend", days],
+    queryKey: ["leadsTrend", days, isAdminView],
     queryFn: async () => {
       const startDate = subDays(new Date(), days);
 
@@ -276,9 +280,10 @@ export function useLeadsTrend(days: number = 30) {
 
 export function useRevenueTrend(months: number = 6) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["revenueTrend", months],
+    queryKey: ["revenueTrend", months, isAdminView],
     queryFn: async () => {
       const startDate = subMonths(new Date(), months);
 
@@ -316,9 +321,10 @@ export function useRevenueTrend(months: number = 6) {
 
 export function usePipelineFunnel() {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["pipelineFunnel"],
+    queryKey: ["pipelineFunnel", isAdminView],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("businesses")
@@ -350,9 +356,10 @@ export function usePipelineFunnel() {
 
 export function useActivityHeatmap(weeks: number = 12) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["activityHeatmap", weeks],
+    queryKey: ["activityHeatmap", weeks, isAdminView],
     retry: 1,
     queryFn: async () => {
       const startDate = subWeeks(new Date(), weeks);
@@ -403,9 +410,10 @@ export function useActivityHeatmap(weeks: number = 12) {
 
 export function useRecentActivities(limit: number = 10) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["recentActivities", limit],
+    queryKey: ["recentActivities", limit, isAdminView],
     retry: 1,
     queryFn: async () => {
       const { data, error } = await supabase
@@ -429,9 +437,10 @@ export function useRecentActivities(limit: number = 10) {
 
 export function useTopPerformers() {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["topPerformers"],
+    queryKey: ["topPerformers", isAdminView],
     queryFn: async () => {
       // Get activities grouped by user
       const { data: activities, error: activitiesError } = await supabase

--- a/lib/hooks/useCampaigns.ts
+++ b/lib/hooks/useCampaigns.ts
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getSupabaseClient } from "@/lib/supabase/client";
 import type { InsertTables, UpdateTables } from "@/lib/types/database";
 import { checkResourceLimit } from "@/lib/hooks/useGatedMutation";
+import { useViewMode } from "@/lib/contexts/ViewModeContext";
 
 export interface CampaignFilters {
   status?: string;
@@ -13,9 +14,10 @@ export interface CampaignFilters {
 
 export function useCampaigns(filters: CampaignFilters = {}) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["campaigns", filters],
+    queryKey: ["campaigns", filters, isAdminView],
     queryFn: async () => {
       let query = supabase
         .from("campaigns")

--- a/lib/hooks/useContacts.ts
+++ b/lib/hooks/useContacts.ts
@@ -4,13 +4,15 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getSupabaseClient } from "@/lib/supabase/client";
 import type { InsertTables, UpdateTables } from "@/lib/types/database";
 import { useRealtimeSubscription } from "@/lib/hooks/useRealtime";
+import { useViewMode } from "@/lib/contexts/ViewModeContext";
 
 export function useContacts(businessId?: string) {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
   useRealtimeSubscription("contacts", [["contacts", businessId], ["contacts"]]);
 
   return useQuery({
-    queryKey: ["contacts", businessId],
+    queryKey: ["contacts", businessId, isAdminView],
     queryFn: async () => {
       let query = supabase
         .from("contacts")

--- a/lib/hooks/useLeads.ts
+++ b/lib/hooks/useLeads.ts
@@ -5,6 +5,7 @@ import { getSupabaseClient } from "@/lib/supabase/client";
 import type { Business, InsertTables, UpdateTables } from "@/lib/types/database";
 import { checkResourceLimit } from "@/lib/hooks/useGatedMutation";
 import { useRealtimeSubscription } from "@/lib/hooks/useRealtime";
+import { useViewMode } from "@/lib/contexts/ViewModeContext";
 
 export interface LeadFilters {
   status?: string;
@@ -32,10 +33,11 @@ export interface UseLeadsOptions {
 export function useLeads(options: UseLeadsOptions = {}) {
   const { page = 1, pageSize = 25, filters = {}, sort } = options;
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
   useRealtimeSubscription("businesses", [["leads"]]);
 
   return useQuery({
-    queryKey: ["leads", page, pageSize, filters, sort],
+    queryKey: ["leads", page, pageSize, filters, sort, isAdminView],
     queryFn: async () => {
       let query = supabase
         .from("businesses")
@@ -298,9 +300,10 @@ export function useBulkUpdateLeads() {
 
 export function useLeadStats() {
   const supabase = getSupabaseClient();
+  const { isAdminView } = useViewMode();
 
   return useQuery({
-    queryKey: ["leadStats"],
+    queryKey: ["leadStats", isAdminView],
     queryFn: async () => {
       // Get counts by status
       const { data: statusCounts, error: statusError } = await supabase


### PR DESCRIPTION
## Summary
- **Admin mode re-fetch (#45)**: All data hooks now include `isAdminView` in React Query keys, so toggling admin mode triggers fresh data fetches instead of serving stale user-mode cache
- **Campaign title truncation (#47)**: Changed `line-clamp-1` to `line-clamp-2` on campaign card titles
- **Plan gating (#48)**: Free tier users now see a clear upgrade prompt instead of a confusing "Not available" banner with campaign data still rendering below it

## Changes
| File | Change |
|------|--------|
| `lib/hooks/useLeads.ts` | Added `isAdminView` to query keys for `useLeads` and `useLeadStats` |
| `lib/hooks/useContacts.ts` | Added `isAdminView` to `useContacts` query key |
| `lib/hooks/useActivities.ts` | Added `isAdminView` to `useActivities` query key |
| `lib/hooks/useCampaigns.ts` | Added `isAdminView` to `useCampaigns` query key |
| `lib/hooks/useAnalytics.ts` | Added `isAdminView` to all 8 analytics hook query keys |
| `components/campaigns/CampaignCard.tsx` | `line-clamp-1` -> `line-clamp-2` on title |
| `app/(dashboard)/campaigns/page.tsx` | Gated campaign content behind `useSubscription().can("campaigns")`, shows upgrade prompt for free tier |

## How admin mode works
1. User toggles admin view -> `isAdminView` changes in ViewModeContext
2. All hooks include `isAdminView` in query keys -> React Query sees a new key -> triggers re-fetch
3. Supabase RLS policies have admin exceptions (`role IN ('admin','manager')`) -> admin users see all data
4. The hooks themselves don't filter differently — RLS handles visibility at the database level

## Test plan
- [ ] Toggle admin mode -> verify dashboard/leads/contacts/activities all re-fetch and show data
- [ ] Toggle back to user mode -> verify data re-fetches with user-scoped view
- [ ] Check campaign card titles render fully (no truncation on short names)
- [ ] Free tier user sees upgrade prompt on campaigns page, no campaign data below it
- [ ] Paid tier user sees campaign data normally with usage bar

Closes #45, Closes #47, Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)