### PR TITLE
fix: correct field name mismatches and null safety

### DIFF
--- a/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/app/(dashboard)/campaigns/[id]/page.tsx
@@ -313,19 +313,19 @@ export default function CampaignDetailPage() {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              {campaign.start_date && (
+              {campaign.started_at && (
                 <div className="flex justify-between">
                   <span className="text-text-muted">Start Date</span>
                   <span className="text-text-primary">
-                    {format(new Date(campaign.start_date), "MMM d, yyyy")}
+                    {format(new Date(campaign.started_at), "MMM d, yyyy")}
                   </span>
                 </div>
               )}
-              {campaign.end_date && (
+              {campaign.ended_at && (
                 <div className="flex justify-between">
                   <span className="text-text-muted">End Date</span>
                   <span className="text-text-primary">
-                    {format(new Date(campaign.end_date), "MMM d, yyyy")}
+                    {format(new Date(campaign.ended_at), "MMM d, yyyy")}
                   </span>
                 </div>
               )}

--- a/app/(dashboard)/contacts/page.tsx
+++ b/app/(dashboard)/contacts/page.tsx
@@ -28,16 +28,16 @@ export default function ContactsPage() {
     if (!searchQuery) return true;
     const query = searchQuery.toLowerCase();
     return (
-      contact.first_name.toLowerCase().includes(query) ||
-      contact.last_name.toLowerCase().includes(query) ||
+      (contact.first_name ?? "").toLowerCase().includes(query) ||
+      (contact.last_name ?? "").toLowerCase().includes(query) ||
       contact.email?.toLowerCase().includes(query) ||
-      contact.job_title?.toLowerCase().includes(query)
+      contact.title?.toLowerCase().includes(query)
     );
   });
 
   // Group contacts by first letter
   const groupedContacts = filteredContacts?.reduce((acc, contact) => {
-    const letter = contact.first_name[0].toUpperCase();
+    const letter = (contact.first_name ?? "?")[0].toUpperCase();
     if (!acc[letter]) acc[letter] = [];
     acc[letter].push(contact);
     return acc;
@@ -135,8 +135,8 @@ export default function ContactsPage() {
                               : "bg-white/10 text-text-secondary"
                           )}
                         >
-                          {contact.first_name[0]}
-                          {contact.last_name[0]}
+                          {(contact.first_name ?? "?")[0]}
+                          {(contact.last_name ?? "")[0]}
                         </div>
 
                         {/* Info */}
@@ -152,9 +152,9 @@ export default function ContactsPage() {
                               </Badge>
                             )}
                           </div>
-                          {contact.job_title && (
+                          {contact.title && (
                             <p className="text-sm text-text-secondary">
-                              {contact.job_title}
+                              {contact.title}
                               {contact.department && ` - ${contact.department}`}
                             </p>
                           )}

--- a/components/campaigns/CampaignCard.tsx
+++ b/components/campaigns/CampaignCard.tsx
@@ -28,8 +28,8 @@ interface CampaignCardProps {
     name: string;
     campaign_type: string;
     status: string;
-    start_date: string | null;
-    end_date: string | null;
+    started_at: string | null;
+    ended_at: string | null;
     budget: number | null;
     spent: number | null;
     target_count: number | null;
@@ -66,12 +66,12 @@ export function CampaignCard({ campaign, onStatusChange }: CampaignCardProps) {
         <CardContent className="pt-4">
           {/* Header */}
           <div className="flex items-start justify-between gap-2 mb-3">
-            <div className="flex items-center gap-2">
-              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gold/20 text-gold">
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gold/20 text-gold">
                 {typeIcon}
               </div>
-              <div>
-                <h3 className="font-medium text-text-primary line-clamp-2">
+              <div className="min-w-0">
+                <h3 className="font-medium text-text-primary break-words">
                   {campaign.name}
                 </h3>
                 <p className="text-xs text-text-muted capitalize">
@@ -99,12 +99,12 @@ export function CampaignCard({ campaign, onStatusChange }: CampaignCardProps) {
                 </span>
               </div>
             )}
-            {campaign.start_date && (
+            {campaign.started_at && (
               <div className="flex items-center gap-2 text-sm">
                 <Calendar className="h-4 w-4 text-text-muted" />
                 <span className="text-text-secondary">
-                  {format(new Date(campaign.start_date), "MMM d")}
-                  {campaign.end_date && ` - ${format(new Date(campaign.end_date), "MMM d")}`}
+                  {format(new Date(campaign.started_at), "MMM d")}
+                  {campaign.ended_at && ` - ${format(new Date(campaign.ended_at), "MMM d")}`}
                 </span>
               </div>
             )}

--- a/components/campaigns/CampaignForm.tsx
+++ b/components/campaigns/CampaignForm.tsx
@@ -27,8 +27,8 @@ interface CampaignFormProps {
     campaign_type: string;
     status: string;
     description: string | null;
-    start_date: string | null;
-    end_date: string | null;
+    started_at: string | null;
+    ended_at: string | null;
     budget: number | null;
     target_count: number | null;
     target_criteria: Record<string, unknown> | null;
@@ -51,8 +51,8 @@ export function CampaignForm({
     campaign_type: initialData?.campaign_type || "email",
     status: initialData?.status || "draft",
     description: initialData?.description || "",
-    start_date: initialData?.start_date?.split("T")[0] || "",
-    end_date: initialData?.end_date?.split("T")[0] || "",
+    started_at: initialData?.started_at?.split("T")[0] || "",
+    ended_at: initialData?.ended_at?.split("T")[0] || "",
     budget: initialData?.budget?.toString() || "",
     target_count: initialData?.target_count?.toString() || "",
   });
@@ -77,8 +77,8 @@ export function CampaignForm({
       campaign_type: formData.campaign_type,
       status: formData.status,
       description: formData.description || null,
-      start_date: formData.start_date || null,
-      end_date: formData.end_date || null,
+      started_at: formData.started_at || null,
+      ended_at: formData.ended_at || null,
       budget: formData.budget ? parseFloat(formData.budget) : null,
       target_count: formData.target_count ? parseInt(formData.target_count) : null,
     };
@@ -193,16 +193,16 @@ export function CampaignForm({
           <Input
             label="Start Date"
             type="date"
-            value={formData.start_date}
-            onChange={(e) => updateField("start_date", e.target.value)}
+            value={formData.started_at}
+            onChange={(e) => updateField("started_at", e.target.value)}
             error={errors.start_date}
             leftIcon={<Calendar className="h-4 w-4" />}
           />
           <Input
             label="End Date"
             type="date"
-            value={formData.end_date}
-            onChange={(e) => updateField("end_date", e.target.value)}
+            value={formData.ended_at}
+            onChange={(e) => updateField("ended_at", e.target.value)}
             error={errors.end_date}
             leftIcon={<Calendar className="h-4 w-4" />}
           />

--- a/lib/hooks/useCampaigns.ts
+++ b/lib/hooks/useCampaigns.ts
@@ -57,7 +57,7 @@ export function useCampaign(id: string) {
             id,
             business_id,
             status,
-            added_at,
+            created_at,
             businesses(business_name, email, status)
           )
         `)


### PR DESCRIPTION
## Summary
- **Campaign field names**: `start_date`/`end_date` → `started_at`/`ended_at` across CampaignCard, CampaignForm, and campaign detail page to match the actual database schema
- **Campaign members query**: `added_at` → `created_at` in `useCampaign` hook — the `added_at` column doesn't exist on `campaign_members`, causing a Supabase 400 error on campaign detail pages
- **Contacts field names**: `job_title` → `title` to match the contacts table schema
- **Contacts null safety**: Added null coalescing for `first_name`/`last_name` which are nullable columns, preventing runtime crashes on the contacts page
- **Campaign card layout**: Replaced `line-clamp-2` with proper flex layout (`min-w-0`, `shrink-0`, `break-words`) for better title wrapping

## Changed files
| File | Change |
|------|--------|
| `components/campaigns/CampaignCard.tsx` | `start_date`/`end_date` → `started_at`/`ended_at`, improved title flex layout |
| `components/campaigns/CampaignForm.tsx` | `start_date`/`end_date` → `started_at`/`ended_at` in interface, state, and submission |
| `app/(dashboard)/campaigns/[id]/page.tsx` | `start_date`/`end_date` → `started_at`/`ended_at` in schedule section |
| `lib/hooks/useCampaigns.ts` | `added_at` → `created_at` in campaign_members select |
| `app/(dashboard)/contacts/page.tsx` | `job_title` → `title`, null safety for `first_name`/`last_name` |

## Test plan
- [ ] Open campaign detail page — verify no 400 error, dates display correctly
- [ ] Create/edit a campaign — verify start/end dates save and load correctly
- [ ] View campaign cards — verify titles wrap properly and dates show
- [ ] View contacts page — verify search works, contacts with null names don't crash
- [ ] Check contact avatars render initials correctly even with null names

🤖 Generated with [Claude Code](https://claude.com/claude-code)