### PR TITLE
ci: add E2E tests to pipeline, fix staging deploy, add Vercel CI gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,75 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nextjs-build
+          path: |
+            .next/
+            !.next/cache/
+          retention-days: 1
+
+  # E2E tests run after build passes. Currently allowed to fail because
+  # Playwright specs require a running Supabase instance with seeded data
+  # and valid auth credentials. Once a dedicated CI Supabase project or
+  # local Supabase (via Docker) is configured, remove continue-on-error.
+  e2e-tests:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: [build]
+    continue-on-error: true
+    timeout-minutes: 30
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
+      SUPABASE_SERVICE_ROLE_KEY: placeholder-service-role-key
+      NEXT_PUBLIC_APP_URL: http://localhost:3004
+      CI: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nextjs-build
+          path: .next/
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Start Next.js server
+        run: npm run start -- -p 3004 &
+        env:
+          PORT: 3004
+      - name: Wait for server to be ready
+        run: |
+          echo "Waiting for http://localhost:3004 to be ready..."
+          for i in $(seq 1 60); do
+            if curl -s -o /dev/null -w '' http://localhost:3004 2>/dev/null; then
+              echo "Server is ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Server failed to start within 60 seconds"
+              exit 1
+            fi
+            sleep 1
+          done
+      - name: Run Playwright tests
+        run: npx playwright test --project=chromium
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-test-results
+          path: test-results/
+          retention-days: 14

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -32,6 +32,8 @@ jobs:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     needs: [lint-and-test]
+    outputs:
+      deployment-url: ${{ steps.deploy.outputs.url }}
     environment:
       name: staging
       url: ${{ steps.deploy.outputs.url }}
@@ -69,8 +71,12 @@ jobs:
       - name: Wait for deployment to stabilize
         run: sleep 15
       - name: Health check
+        env:
+          DEPLOY_URL: ${{ needs.deploy-staging.outputs.deployment-url }}
         run: |
-          STATUS=$(curl -o /dev/null -s -w "%{http_code}" "${{ needs.deploy-staging.outputs.url || 'https://staging-goldyon.vercel.app' }}")
+          TARGET_URL="${DEPLOY_URL:-https://staging-goldyon.vercel.app}"
+          echo "Running health check against: $TARGET_URL"
+          STATUS=$(curl -o /dev/null -s -w "%{http_code}" "$TARGET_URL")
           if [ "$STATUS" -ne 200 ]; then
             echo "Health check failed with status $STATUS"
             exit 1

--- a/vercel.json
+++ b/vercel.json
@@ -28,5 +28,8 @@
     "deploymentEnabled": {
       "master": true
     }
+  },
+  "github": {
+    "silent": true
   }
 }


### PR DESCRIPTION
## Summary
- **E2E tests in CI**: New `e2e-tests` job in ci.yml — downloads build artifact, installs Chromium, starts Next.js server, runs Playwright. `continue-on-error: true` initially (needs running Supabase).
- **Staging smoke test fix**: Added missing `outputs` declaration to `deploy-staging` job so smoke test receives the deployment URL.
- **Vercel CI gating**: Added `"github": { "silent": true }` to vercel.json so Vercel doesn't post its own status checks that bypass CI.

## Test plan
- [ ] Verify CI pipeline still passes (lint, typecheck, tests, build)
- [ ] Verify E2E job appears in CI runs (expected to fail gracefully without Supabase)
- [ ] Verify staging workflow syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)